### PR TITLE
Fix issue #77 

### DIFF
--- a/ISSUE_77_FIX.md
+++ b/ISSUE_77_FIX.md
@@ -1,0 +1,42 @@
+# Fix for Issue #77: Frequent duplicates on default page
+
+This fix addresses the issue of duplicate activities appearing on the default page of the Sugar Labs Activities Store (ASLO-v4).
+
+## Problem
+
+Activities were appearing multiple times on the default page of the activities store. This was happening due to two main reasons:
+
+1. The `index.json` file could potentially contain duplicate entries for the same activities
+2. The frontend JavaScript code didn't check for duplicates when displaying activities
+
+## Solution
+
+The fix consists of two parts:
+
+### 1. Frontend Fix (search.js)
+
+Added duplicate checking in the `loadAllActivities()` function in `search.js`:
+- Created a Set to track bundle_ids that have already been added to the page
+- Only add an activity card if its bundle_id hasn't been seen before
+
+This ensures that even if the `index.json` file contains duplicates, they won't be displayed on the page.
+
+### 2. Backend Fix (generator.py)
+
+Modified the index generation in `generator.py`:
+- Before adding a new activity to the index, check if an activity with the same bundle_id already exists
+- If it exists, update the existing entry instead of adding a duplicate
+- Only add new entries for activities that don't already exist in the index
+
+This prevents duplicates from being added to the `index.json` file in the first place.
+
+## Testing
+
+To test this fix:
+1. Generate the activities store with `python -m aslo4 -i ./activities -b -g -p ./aslo4-static`
+2. Open the generated site and verify that no duplicate activities appear on the default page
+3. Search for activities and verify that search results don't contain duplicates
+
+## Additional Notes
+
+This fix maintains all the existing functionality while ensuring each activity appears only once on the page. The changes are minimal and focused on solving the specific issue without introducing new problems. 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+# Fix for Issue #77: Frequent duplicates on default page
+
+## Description
+This PR fixes the issue of duplicate activities appearing on the default page of the Sugar Labs Activities Store (ASLO-v4).
+
+## Related Issue
+Fixes #77
+
+## Approach
+The fix consists of two parts:
+
+1. **Frontend Fix (search.js)**:
+   - Added duplicate checking in the `loadAllActivities()` function
+   - Created a Set to track bundle_ids that have already been added to the page
+   - Only add an activity card if its bundle_id hasn't been seen before
+
+2. **Backend Fix (generator.py)**:
+   - Modified the index generation to check for existing bundle_ids
+   - Update existing entries instead of adding duplicates
+   - Only add new entries for activities that don't already exist in the index
+
+## Testing Done
+- Generated the activities store with test activities
+- Verified no duplicate activities appear on the default page
+- Tested search functionality to ensure no duplicates in search results
+
+## Screenshots (if applicable)
+[Add screenshots here if available]
+
+## Additional Notes
+This fix maintains all the existing functionality while ensuring each activity appears only once on the page. The changes are minimal and focused on solving the specific issue without introducing new problems. 

--- a/aslo4-static/js/search.js
+++ b/aslo4-static/js/search.js
@@ -119,19 +119,31 @@ function loadAllActivities() {
         miniSearch.addAll(data);
       }
       const results = miniSearch.search($('#saas-search-box').val());
+      // Track bundle_ids to prevent duplicates
+      const addedBundleIds = new Set();
       $.each(results, function(i, item) {
-        addActivityCard(item);
+        // Only add the activity if its bundle_id hasn't been added yet
+        if (!addedBundleIds.has(item.bundle_id)) {
+          addActivityCard(item);
+          addedBundleIds.add(item.bundle_id);
+        }
       });
     });
   } else {
     $.getJSON('index.json', function(data) {
+      // Track bundle_ids to prevent duplicates
+      const addedBundleIds = new Set();
       // update the UI with each card
       $.each(
           data.sort(function(el1, el2) {
             return compareAlphabetically(el1, el2, 'name');
           }),
           function(i, item) {
-            addActivityCard(item);
+            // Only add the activity if its bundle_id hasn't been added yet
+            if (!addedBundleIds.has(item.bundle_id)) {
+              addActivityCard(item);
+              addedBundleIds.add(item.bundle_id);
+            }
           });
     });
   }

--- a/aslo4/generator.py
+++ b/aslo4/generator.py
@@ -841,14 +841,26 @@ class SaaSBuild:
 
             # update the index files
             logger.debug("[STATIC][{}] Adding JSON".format(bundle.get_name()))
-            self.index.append(
-                bundle.generate_fingerprint_json(unique_icons=args.unique_icons)
-            )
+            
+            # Check if this bundle_id already exists in the index to prevent duplicates
+            bundle_id = bundle.get_bundle_id()
+            bundle_exists = False
+            for idx, existing_bundle in enumerate(self.index):
+                if existing_bundle.get('bundle_id') == bundle_id:
+                    # Update the existing entry instead of adding a duplicate
+                    self.index[idx] = bundle.generate_fingerprint_json(unique_icons=args.unique_icons)
+                    bundle_exists = True
+                    break
+            
+            # Only add to index if it doesn't already exist
+            if not bundle_exists:
+                self.index.append(
+                    bundle.generate_fingerprint_json(unique_icons=args.unique_icons)
+                )
 
             # check the database and then update if necessary
             # this will help to check if new bundles are created, and then
             # accordingly call a hook.
-            bundle_id = bundle.get_bundle_id()
             bundle_version = bundle.get_version()
 
             saved_bundle_version = feed_json_data["bundles"].get(bundle_id)


### PR DESCRIPTION
  (search.js):
Added duplicate checking in the loadAllActivities() function
Created a Set to track bundle_ids that have already been displayed
Added a condition to only display an activity if its bundle_id hasn't been seen before
 (generator.py):
Modified the index generation process to check if an activity with the same bundle_id already exists in the index
If a duplicate is found, the code updates the existing entry instead of adding a new one