### PR TITLE
Fix issue #77: Prevent duplicates on default page 

### DIFF
--- a/aslo4-static/js/search.js
+++ b/aslo4-static/js/search.js
@@ -119,19 +119,31 @@ function loadAllActivities() {
         miniSearch.addAll(data);
       }
       const results = miniSearch.search($('#saas-search-box').val());
+      // Track bundle_ids to prevent duplicates
+      const addedBundleIds = new Set();
       $.each(results, function(i, item) {
-        addActivityCard(item);
+        // Only add the activity if its bundle_id hasn't been added yet
+        if (!addedBundleIds.has(item.bundle_id)) {
+          addActivityCard(item);
+          addedBundleIds.add(item.bundle_id);
+        }
       });
     });
   } else {
     $.getJSON('index.json', function(data) {
+      // Track bundle_ids to prevent duplicates
+      const addedBundleIds = new Set();
       // update the UI with each card
       $.each(
           data.sort(function(el1, el2) {
             return compareAlphabetically(el1, el2, 'name');
           }),
           function(i, item) {
-            addActivityCard(item);
+            // Only add the activity if its bundle_id hasn't been added yet
+            if (!addedBundleIds.has(item.bundle_id)) {
+              addActivityCard(item);
+              addedBundleIds.add(item.bundle_id);
+            }
           });
     });
   }

--- a/aslo4/generator.py
+++ b/aslo4/generator.py
@@ -841,14 +841,35 @@ class SaaSBuild:
 
             # update the index files
             logger.debug("[STATIC][{}] Adding JSON".format(bundle.get_name()))
-            self.index.append(
-                bundle.generate_fingerprint_json(unique_icons=args.unique_icons)
-            )
+            
+            # Get the bundle_id
+            bundle_id = bundle.get_bundle_id()
+            
+            # Use a dictionary to track bundle_ids for efficient lookup
+            # Initialize the dictionary if it doesn't exist yet
+            if not hasattr(self, 'bundle_id_index'):
+                self.bundle_id_index = {}
+                # Populate with existing bundles
+                for idx, existing_bundle in enumerate(self.index):
+                    if 'bundle_id' in existing_bundle:
+                        self.bundle_id_index[existing_bundle['bundle_id']] = idx
+            
+            # Check if this bundle_id already exists in the index
+            if bundle_id in self.bundle_id_index:
+                # Update the existing entry instead of adding a duplicate
+                idx = self.bundle_id_index[bundle_id]
+                self.index[idx] = bundle.generate_fingerprint_json(unique_icons=args.unique_icons)
+            else:
+                # Add to index if it doesn't already exist
+                self.index.append(
+                    bundle.generate_fingerprint_json(unique_icons=args.unique_icons)
+                )
+                # Update the lookup dictionary
+                self.bundle_id_index[bundle_id] = len(self.index) - 1
 
             # check the database and then update if necessary
             # this will help to check if new bundles are created, and then
             # accordingly call a hook.
-            bundle_id = bundle.get_bundle_id()
             bundle_version = bundle.get_version()
 
             saved_bundle_version = feed_json_data["bundles"].get(bundle_id)


### PR DESCRIPTION
Using a dictionary for O(1) constant-time lookups instead of O(n) linear searches
Only initializing the dictionary once and maintaining it as new entries are added
Updating existing entries instead of adding duplicates