### PR TITLE
Fix #89

### DIFF
--- a/aslo4/bundle/bundle.py
+++ b/aslo4/bundle/bundle.py
@@ -837,4 +837,5 @@ class Bundle:
         out, _ = url_process.communicate()
         url = out.decode().split("\n")
         if len(url) >= 1:
-            return url[0]
+            url = url[0].replace('git@github.com:', 'https://github.com/')
+            return url


### PR DESCRIPTION
## Summary:
This PR fixes issue #89 .
Now the source code button works & redirects to the right page even if an activity is cloned via SSH.

## What it does:
- I updated the `get_git_url` function in `bundle.py`. This function now returns a tuple of the format:
` (repo_hosting_service , repo_name) `

- Later, this is converted into its corresponding link in `app.html` using the format:
` https://{{ repo_host_service }}/{{ repo_name }} `

> Note: This design ensures that tomorrow if sugar wants to use another repository hosting platform (eg: gitlab), this code would still work.

## Testing:
- I have tested the changes locally and ensured that it works as intended irrespective of whether the activity is cloned via HTTPS or SSH.
![Sugarlabs-issue-89-2](https://github.com/user-attachments/assets/3bc6d1ae-362e-456f-9b05-707c2959e598)
![Sugarlabs-issue-89-1](https://github.com/user-attachments/assets/63c515ed-8dd7-40a3-94d4-5f61ee30c096)

----------
@chimosky @walterbender I would have liked to include this PR in my GSoC '25 Proposal, but I won't be able to edit it now. I hope this PR won't go unnoticed. 

@quozl I hope I learnt from my mistakes last time. I hope this PR aligns with the contribution requirements.
Do let me know if anything needs to be changed or improved upon. Thanks
